### PR TITLE
Feature/action changelog

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,48 @@
+name: Prepare release
+on:
+  push:
+    branches:
+    - 'release/**'
+
+jobs:
+  job_compute_release_name:
+    runs-on: ubuntu-18.04
+    container:
+      image: docker://alpine/git:v2.24.3
+    outputs:
+      release_name: ${{ steps.step_compute_release_name.outputs.release_name }}
+    steps:
+      - id: step_compute_release_name
+        env:
+          GIT_REF: ${{ github.ref }}
+        run: |
+          release_name=${GIT_REF#refs/heads/release/}
+          echo "Release name=$release_name"
+          echo "::set-output name=release_name::$release_name"
+
+  job_create_prepare_release_pr:
+    needs: [job_compute_release_name]
+    runs-on: ubuntu-18.04
+    container:
+      image: docker://alpine/git:v2.24.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate changelog file
+        uses: faberNovel/github-changelog-generator-action@v1.0.0-alpha02
+        with:
+          options: --token ${{ secrets.GITHUB_TOKEN }} --since_tag 3.5.0 --future-release ${{ needs.job_compute_release_name.outputs.release_name }}
+
+      - name: Commit changes
+        uses: actions-x/commit@v1
+        with:
+          message: Add changelog
+
+      - name: Create pr
+        id: step_create_pr
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          destination_branch: "master"
+          pr_title: "Prepare release ${{ needs.job_compute_release_name.outputs.release_name }}"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# Changelog
+# History
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),


### PR DESCRIPTION
This PR add a Github Action workflow to automate the process of preparing a release:
When a `release` branch is open, this workflow do the following things:

- Extract release name form release branch name, for example if the branch name is `release/v1.2.3` the release name will be `v1.2.3`.
- Generate the changelog automatically using https://github.com/github-changelog-generator/github-changelog-generator (manual changelog (until 3.5.0) is now in HISTORY.md file, and automatically append at the end of newly generated changelog.
- Commit this generated changelog.
- Open PR targeting `master` branch (there is no `master` branch at this time in the projet, but it could be a good practice to ease release), which let maintainers verify release preparation.

The actual release (publishing artifacts for instance) could be done using another workflow, triggered from a GitHub release creation through the UI of GitHub, allowing a two step release process.
