### PR TITLE
Do not export empty translation on Android

### DIFF
--- a/lib/ad_localize/entities/translation.rb
+++ b/lib/ad_localize/entities/translation.rb
@@ -23,6 +23,10 @@ module AdLocalize
         o.value == value &&
         o.comment == comment
       end
+
+      def has_value?
+        value.present?
+      end
     end
   end
 end

--- a/lib/ad_localize/serializers/strings_serializer.rb
+++ b/lib/ad_localize/serializers/strings_serializer.rb
@@ -22,11 +22,17 @@ module AdLocalize
       end
 
       def map_singulars(translations:)
-        translations.map { |translation| @translation_mapper.map(translation: translation) }
+        usable_translations = translations.select { |translation| translation.value != nil && !translation.value.empty? }
+        usable_translations.map { |translation| @translation_mapper.map(translation: translation) }
       end
 
       def map_plurals(plurals:)
-        plurals.map { |label, translations| @translation_group_mapper.map(label: label, translations: translations) }
+        plurals.map { |label, translations| 
+          usable_translations = translations.select { |translation| translation.value != nil && !translation.value.empty? }
+          @translation_group_mapper.map(label: label, translations: usable_translations) 
+      }.select { |translation|
+        !translation.translation_view_models.empty?
+      }
       end
     end
   end

--- a/lib/ad_localize/serializers/strings_serializer.rb
+++ b/lib/ad_localize/serializers/strings_serializer.rb
@@ -22,17 +22,13 @@ module AdLocalize
       end
 
       def map_singulars(translations:)
-        usable_translations = translations.select { |translation| translation.value != nil && !translation.value.empty? }
-        usable_translations.map { |translation| @translation_mapper.map(translation: translation) }
+        translations.select(&:has_value?).map { |translation| @translation_mapper.map(translation: translation) }
       end
 
       def map_plurals(plurals:)
-        plurals.map { |label, translations| 
-          usable_translations = translations.select { |translation| translation.value != nil && !translation.value.empty? }
-          @translation_group_mapper.map(label: label, translations: usable_translations) 
-      }.select { |translation|
-        !translation.translation_view_models.empty?
-      }
+        plurals
+        .map { |label, translations| @translation_group_mapper.map(label: label, translations: translations.select(&:has_value?)) }
+        .select(&:has_translations?)
       end
     end
   end

--- a/lib/ad_localize/view_models/translation_group_view_model.rb
+++ b/lib/ad_localize/view_models/translation_group_view_model.rb
@@ -12,7 +12,7 @@ module AdLocalize
       end
 
       def has_translations?
-        (translation_view_models || []).any? { |translation| translation.value.present? }
+        (translation_view_models || []).any?(&:has_value?)
       end
     end
   end

--- a/lib/ad_localize/view_models/translation_group_view_model.rb
+++ b/lib/ad_localize/view_models/translation_group_view_model.rb
@@ -10,6 +10,10 @@ module AdLocalize
         @label = label
         @translation_view_models = translation_view_models
       end
+
+      def has_translations?
+        (translation_view_models || []).any? { |translation| translation.value.present? }
+      end
     end
   end
 end

--- a/lib/ad_localize/view_models/translation_view_model.rb
+++ b/lib/ad_localize/view_models/translation_view_model.rb
@@ -14,6 +14,10 @@ module AdLocalize
         @value = value
         @comment = comment
       end
+
+      def has_value?
+        value.present?
+      end
     end
   end
 end


### PR DESCRIPTION
Android can handle when a translation is missing, but if the translation is empty Android will display an empty string, which is not what we want.