### PR TITLE
Feature/allow not stripping values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- new option `--skip-value-stripping` that disable the leading and trailing whitespaces removal on wording values. The value stripping was introduced with version 6.0.0.
+
 ## 6.1.0
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ $ ad_localize --auto-escape-percent
 $ ad_localize -l fr,en
 ```
 
+* Keep extra spaces before and after translated values
+```
+$ ad_localize --skip-value-stripping
+```
+
 ### In a Ruby program
 There are many possibilities when using AdLocalize in a ruby program. You can add support to your own wording format, support other platforms, select which locales you want to export, generate wording file content without writing on the disk and many more.
 

--- a/lib/ad_localize/mappers/options_to_export_request.rb
+++ b/lib/ad_localize/mappers/options_to_export_request.rb
@@ -7,6 +7,7 @@ module AdLocalize
         request.locales = options[:locales]
         request.bypass_empty_values = options[:'non-empty-values']
         request.auto_escape_percent = options[:'auto-escape-percent']
+        request.skip_value_stripping = options[:'skip-value-stripping']
         request.csv_paths = options[:csv_paths]
         request.merge_policy = options[:'merge-policy']
         request.output_path = options[:'target-dir']

--- a/lib/ad_localize/option_handler.rb
+++ b/lib/ad_localize/option_handler.rb
@@ -5,6 +5,7 @@ module AdLocalize
       locales: Requests::ExportRequest::DEFAULTS[:locales],
       :'non-empty-values' => Requests::ExportRequest::DEFAULTS[:bypass_empty_values],
       :'auto-escape-percent' => Requests::ExportRequest::DEFAULTS[:auto_escape_percent],
+      :'skip-value-stripping' => Requests::ExportRequest::DEFAULTS[:skip_value_stripping],
       csv_paths: Requests::ExportRequest::DEFAULTS[:csv_paths],
       :'merge-policy' => Requests::ExportRequest::DEFAULTS[:merge_policy],
       :'target-dir' => Requests::ExportRequest::DEFAULTS[:output_path],
@@ -39,6 +40,7 @@ module AdLocalize
         end
         parser.on("-x", "--non-empty-values", TrueClass, 'Do not export keys with empty values (iOS only)')
         parser.on("--auto-escape-percent", TrueClass, 'Add escaping for % symbol to support wording use with String formatting (iOS only)')
+        parser.on("--skip-value-stripping", TrueClass, 'Disable the removal of leading and trailing whitespaces on wording values')
       end.parse!(options, into: args)
 
       args[:csv_paths] = options

--- a/lib/ad_localize/parsers/csv_parser.rb
+++ b/lib/ad_localize/parsers/csv_parser.rb
@@ -73,7 +73,8 @@ module AdLocalize
             next if export_request.bypass_empty_values && value.blank?
 
             comment = row["#{COMMENT_KEY_COLUMN_IDENTIFIER} #{locale}"]
-            wording[locale].add_wording(key: key, value: value&.strip, comment: comment)
+            value = value&.strip unless export_request.skip_value_stripping
+            wording[locale].add_wording(key: key, value: value, comment: comment)
           end
           added_keys[raw_key] = true
         end

--- a/lib/ad_localize/requests/export_request.rb
+++ b/lib/ad_localize/requests/export_request.rb
@@ -6,6 +6,7 @@ module AdLocalize
         locales: [],
         bypass_empty_values: false,
         auto_escape_percent: false,
+        skip_value_stripping: false,
         csv_paths: [],
         merge_policy: Interactors::MergeWordings::DEFAULT_POLICY,
         output_path: Pathname.new('exports'),
@@ -23,6 +24,7 @@ module AdLocalize
         :locales,
         :bypass_empty_values,
         :auto_escape_percent,
+        :skip_value_stripping,
         :csv_paths,
         :merge_policy,
         :output_path,
@@ -38,6 +40,7 @@ module AdLocalize
         @locales = DEFAULTS[:locales]
         @bypass_empty_values = DEFAULTS[:bypass_empty_values]
         @auto_escape_percent = DEFAULTS[:auto_escape_percent]
+        @skip_value_stripping = DEFAULTS[:skip_value_stripping]
         @csv_paths = DEFAULTS[:csv_paths]
         @merge_policy = DEFAULTS[:merge_policy]
         @output_path = DEFAULTS[:output_path]
@@ -61,6 +64,10 @@ module AdLocalize
 
       def auto_escape_percent=(value)
         @auto_escape_percent = [true, 'true'].include?(value)
+      end
+
+      def skip_value_stripping=(value)
+        @skip_value_stripping = [true, 'true'].include?(value)
       end
 
       def csv_paths=(value)
@@ -127,6 +134,7 @@ module AdLocalize
         "locales: #{locales}, " \
           "bypass_empty_values: #{bypass_empty_values}, " \
           "auto_escape_percent: #{auto_escape_percent}, " \
+          "skip_value_stripping: #{skip_value_stripping}, " \
           "csv_paths: #{csv_paths}, " \
           "merge_policy: #{merge_policy}, " \
           "output_path: #{output_path}, " \

--- a/test/fixtures/reference_whitespace_stripping.csv
+++ b/test/fixtures/reference_whitespace_stripping.csv
@@ -1,0 +1,5 @@
+,key,en,
+,no_whitespaces,no_whitespaces,
+,  before,  before,
+,after  ,after  ,
+,  both  ,  both  ,

--- a/test/parsers/csv_parser_test.rb
+++ b/test/parsers/csv_parser_test.rb
@@ -4,6 +4,54 @@ require 'test_helper'
 module AdLocalize
   module Parsers
     class CSVParserTest < TestCase
+      test 'should trim whitespace on keys and translations' do
+        # Given
+        csv_path = "test/fixtures/reference_whitespace_stripping.csv"
+        assert(File.exist?(csv_path), "File does not exists #{csv_path}")
+        parser = Parsers::CSVParser.new
+        export_request = Requests::ExportRequest.new
+
+        # When
+        wording = parser.call(csv_path: csv_path, export_request: export_request)
+
+        # Then
+        en_singular_wording = wording["en"].singulars
+
+        assert_equal en_singular_wording["no_whitespaces"].key.label, "no_whitespaces"
+        assert_equal en_singular_wording["before"].key.label, "before"
+        assert_equal en_singular_wording["after"].key.label, "after"
+        assert_equal en_singular_wording["both"].key.label, "both"
+
+        assert_equal en_singular_wording["no_whitespaces"].value, "no_whitespaces"
+        assert_equal en_singular_wording["before"].value, "before"
+        assert_equal en_singular_wording["after"].value, "after"
+        assert_equal en_singular_wording["both"].value, "both"
+      end
+
+      test 'should not trim whitespace on translation when strip is disabled' do
+        # Given
+        csv_path = "test/fixtures/reference_whitespace_stripping.csv"
+        assert(File.exist?(csv_path), "File does not exists #{csv_path}")
+        parser = Parsers::CSVParser.new
+        export_request = Requests::ExportRequest.new
+        export_request.skip_value_stripping = true
+
+        # When
+        wording = parser.call(csv_path: csv_path, export_request: export_request)
+
+        # Then
+        en_singular_wording = wording["en"].singulars
+
+        assert_equal en_singular_wording["no_whitespaces"].key.label, "no_whitespaces"
+        assert_equal en_singular_wording["before"].key.label, "before"
+        assert_equal en_singular_wording["after"].key.label, "after"
+        assert_equal en_singular_wording["both"].key.label, "both"
+
+        assert_equal en_singular_wording["no_whitespaces"].value, "no_whitespaces"
+        assert_equal en_singular_wording["before"].value, "  before"
+        assert_equal en_singular_wording["after"].value, "after  "
+        assert_equal en_singular_wording["both"].value, "  both  "
+      end
     end
   end
 end


### PR DESCRIPTION
ad_localize v6.0.0 introduced extra space removal from translated values, but those extra spaces can be wanted : for a translation really containing extra spaces, or when migrating from an earlier version.

This PR introduced the option `--skip-value-stripping` which prevent the stripping of translations.